### PR TITLE
Trusted option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ Cyril de Catheu <cdecatheu@gmail.com> (https://catheu.tech/)
 Thomas Miedema <thomasmiedema@gmail.com>
 Hugo van Kemenade (https://github.com/hugovk)
 Jacob Woliver <jacob@jmw.sh> (jmw.sh)
+Ivan Rusanov <ivan.s.rusanov@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,15 @@
 .. image:: https://img.shields.io/github/actions/workflow/status/pypa/twine/main.yml?branch=main
    :target: https://github.com/pypa/twine/actions
 
+About this fork
+------------
+This project was forked from the original Twine repository. The 
+only difference between this fork and original one is the `--trusted` 
+option. This option was added to `twine upload`command in order to make 
+able to skip SSL certificate validation for trusted hosts.
+
+More information can be found in [this issue](https://github.com/pypa/twine/issues/387).
+
 twine
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 
 [tool.towncrier]
-package = "twine"
+package = "twine-twine"
 filename = "docs/changelog.rst"
 directory = "changelog"
 issue_format = "`#{issue} <https://github.com/pypa/twine/issues/{issue}>`_"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 license_file = LICENSE
-name = twine
+name = twine-twine
 author = Donald Stufft and individual contributors
 author_email = donald@stufft.io
 description = Collection of utilities for publishing packages on PyPI

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -84,6 +84,19 @@ def test_set_certificate_authority(default_repo):
     assert default_repo.session.verify == "/path/to/cert"
 
 
+def test_no_ca_verify():
+    repo = repository.Repository(
+        repository_url=utils.DEFAULT_REPOSITORY,
+        username='username',
+        password='password',
+    )
+
+    assert repo.session.verify is True
+
+    repo.set_certificate_authority('/path/to/cert', True)
+    assert not repo.session.verify
+
+
 def test_make_user_agent_string(default_repo):
     """Add twine to User-Agent session header."""
     assert "twine/" in default_repo.session.headers["User-Agent"]

--- a/twine/commands/upload.py
+++ b/twine/commands/upload.py
@@ -15,6 +15,7 @@
 import argparse
 import logging
 import os.path
+import warnings
 from typing import Dict, List, cast
 
 import requests
@@ -145,10 +146,13 @@ def upload(upload_settings: settings.Settings, dists: List[str]) -> None:
             logger.warning(skip_message)
             continue
 
-        resp = repository.upload(package)
-        logger.info(f"Response from {resp.url}:\n{resp.status_code} {resp.reason}")
-        if resp.text:
-            logger.info(resp.text)
+        # Feat 387. Trusted host option.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            resp = repository.upload(package)
+            logger.info(f"Response from {resp.url}:\n{resp.status_code} {resp.reason}")
+            if resp.text:
+                logger.info(resp.text)
 
         # Bug 92. If we get a redirect we should abort because something seems
         # funky. The behaviour is not well defined and redirects being issued

--- a/twine/repository.py
+++ b/twine/repository.py
@@ -100,8 +100,10 @@ class Repository:
                     data_to_send.append((key, item))
         return data_to_send
 
-    def set_certificate_authority(self, cacert: Optional[str]) -> None:
-        if cacert:
+    def set_certificate_authority(self, cacert: Optional[str], trusted: bool = False) -> None:
+        if trusted:
+            self.session.verify = False
+        elif cacert:
             self.session.verify = cacert
 
     def set_client_certificate(self, clientcert: Optional[str]) -> None:


### PR DESCRIPTION
Add --trusted option to allow skipping certificate verification and close issue https://github.com/pypa/twine/issues/387